### PR TITLE
fix: Add countermeasures when a command contains single-byte spaces

### DIFF
--- a/sapientml/executor.py
+++ b/sapientml/executor.py
@@ -53,12 +53,14 @@ def run(
     if platform.system() == "Windows":
         executable = None
         encoding = "cp932"
+        cmd = f'{sys.executable} "{file_path}"'
     else:
         executable = "/bin/bash"
         encoding = "utf-8"
+        cmd = f"{sys.executable} {file_path}"
 
     process = subprocess.Popen(
-        f"{sys.executable} {file_path}",
+        cmd,
         shell=True,
         executable=executable,
         cwd=cwd or os.path.dirname(file_path),


### PR DESCRIPTION
@kimusaku 

* On Windows, fixed an issue that caused the SapientML class fit function to abort if the output folder path contained spaces.