### PR TITLE
feat: export only required libraries

### DIFF
--- a/sapientml/executor.py
+++ b/sapientml/executor.py
@@ -180,15 +180,6 @@ class PipelineExecutor:
         """
         candidate_scripts: list[tuple[Code, RunningResult]] = []
 
-        # copy libs
-        lib_path = output_dir / "lib"
-        lib_path.mkdir(exist_ok=True)
-
-        eps = entry_points(group="sapientml.export_modules")
-        for ep in eps:
-            for file in glob.glob(f"{ep.load().__path__[0]}/*.py"):
-                copyfile(file, lib_path / Path(file).name)
-
         for index, pipeline in enumerate(pipeline_list, start=1):
             script_name = f"{index}_script.py"
             script_path = (output_dir / script_name).absolute().as_posix()

--- a/sapientml/executor.py
+++ b/sapientml/executor.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 import asyncio
-import glob
 import os
 import platform
 import sys
 import time
-from importlib.metadata import entry_points
 from pathlib import Path
-from shutil import copyfile
 from typing import Optional
 
 import nest_asyncio

--- a/sapientml/executor.py
+++ b/sapientml/executor.py
@@ -53,10 +53,10 @@ def run(
     """
 
     if platform.system() == "Windows":
-        encoding = "cp932"
-        replace_newline = "\r"
-        loop = asyncio.ProactorEventLoop()
-        asyncio.set_event_loop(loop)
+        encoding = "cp932"  # noqa
+        replace_newline = "\r"  # noqa
+        loop = asyncio.ProactorEventLoop()  # noqa
+        asyncio.set_event_loop(loop)  # noqa
     else:
         encoding = "utf-8"
         replace_newline = ""
@@ -101,11 +101,11 @@ def run(
                     proc.kill()
                     break
                 if cancel is not None and cancel.is_triggered:
-                    returncode = -9
-                    interrupted_reason = "Cancelled by user"
-                    print("Terminating due to cancellation")
-                    proc.kill()
-                    break
+                    returncode = -9  # noqa
+                    interrupted_reason = "Cancelled by user"  # noqa
+                    print("Terminating due to cancellation")  # noqa
+                    proc.kill()  # noqa
+                    break  # noqa
                 await asyncio.sleep(1)
             return returncode, interrupted_reason
 

--- a/sapientml/main.py
+++ b/sapientml/main.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
 import glob
+import pickle
 
 # from msilib.schema import Error
 from importlib.metadata import entry_points
 from pathlib import Path
-from typing import Literal, Optional, Union
 from shutil import copyfile
+from typing import Literal, Optional, Union
 
 import pandas as pd
 from sapientml.model import GeneratedModel
@@ -171,7 +171,7 @@ class SapientML:
             self._Config = eps_config[model_type].load()
         else:
             raise ValueError(f"Model '{model_type}' is invalid.")
-        
+
         self.model_type = model_type
         self.generator = self._Generator(**kwargs)
         self.config = self.generator.config
@@ -277,7 +277,7 @@ class SapientML:
 
         eps = entry_points(group="sapientml.export_modules")
         for ep in eps:
-            if ep.name in [self.generator.__class__.__name__, 'sample-dataset']:
+            if ep.name in [self.generator.__class__.__name__, "sample-dataset"]:
                 for file in glob.glob(f"{ep.load().__path__[0]}/*.py"):
                     copyfile(file, lib_path / Path(file).name)
 

--- a/sapientml/main.py
+++ b/sapientml/main.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import pickle
+import glob
 
 # from msilib.schema import Error
 from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Literal, Optional, Union
+from shutil import copyfile
 
 import pandas as pd
 from sapientml.model import GeneratedModel
@@ -169,7 +171,7 @@ class SapientML:
             self._Config = eps_config[model_type].load()
         else:
             raise ValueError(f"Model '{model_type}' is invalid.")
-
+        
         self.model_type = model_type
         self.generator = self._Generator(**kwargs)
         self.config = self.generator.config
@@ -268,6 +270,16 @@ class SapientML:
 
         self.output_dir = Path(output_dir).resolve()
         self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # copy libs
+        lib_path = self.output_dir / "lib"
+        lib_path.mkdir(exist_ok=True)
+
+        eps = entry_points(group="sapientml.export_modules")
+        for ep in eps:
+            if ep.name in [self.generator.__class__.__name__, 'sample-dataset']:
+                for file in glob.glob(f"{ep.load().__path__[0]}/*.py"):
+                    copyfile(file, lib_path / Path(file).name)
 
         self.dataset = Dataset(
             training_data=training_data,

--- a/tests/sapientml/test_generatedcode.py
+++ b/tests/sapientml/test_generatedcode.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import pickle
 import tempfile
 from importlib.metadata import entry_points
 from pathlib import Path
+from shutil import copyfile
 
 import pandas as pd
 import pytest
@@ -84,11 +86,23 @@ def make_tempdir(dir=fxdir / "outputs"):
 @pytest.fixture(scope="function")
 def execute_pipeline():
     def _execute(dataset, task, config, temp_dir, initial_timeout=60):
+
         eps = entry_points(group="sapientml.pipeline_generator")
         kwargs = config.model_dump()
         kwargs["initial_timeout"] = initial_timeout
         dataset.output_dir = temp_dir
         generator = eps["sapientml"].load()(**kwargs)
+
+        # copy libs
+        lib_path = dataset.output_dir  / "lib"
+        lib_path.mkdir(exist_ok=True)
+
+        eps = entry_points(group="sapientml.export_modules")
+        for ep in eps:
+            if ep.name in [generator.__class__.__name__, "sample-dataset"]:
+                for file in glob.glob(f"{ep.load().__path__[0]}/*.py"):
+                    copyfile(file, lib_path / Path(file).name)
+
         generator.generate_pipeline(dataset, task)
 
         return generator.execution_results

--- a/tests/sapientml/test_generatedcode.py
+++ b/tests/sapientml/test_generatedcode.py
@@ -86,7 +86,6 @@ def make_tempdir(dir=fxdir / "outputs"):
 @pytest.fixture(scope="function")
 def execute_pipeline():
     def _execute(dataset, task, config, temp_dir, initial_timeout=60):
-
         eps = entry_points(group="sapientml.pipeline_generator")
         kwargs = config.model_dump()
         kwargs["initial_timeout"] = initial_timeout
@@ -94,7 +93,7 @@ def execute_pipeline():
         generator = eps["sapientml"].load()(**kwargs)
 
         # copy libs
-        lib_path = dataset.output_dir  / "lib"
+        lib_path = dataset.output_dir / "lib"
         lib_path.mkdir(exist_ok=True)
 
         eps = entry_points(group="sapientml.export_modules")


### PR DESCRIPTION
@kimusaku 
@AkiraUra 

This PR has been modified to output the bare minimum libraries for analysis.
Before the fix, the library of plug-ins with the group name "sapientml.export_modules" included in the add-on feature would be output to the output directory, regardless of whether the add-on feature was used.
Specifically, fix the following:

```python
# copy libs
lib_path = self.output_dir / "lib"
lib_path.mkdir(exist_ok=True)

eps = entry_points(group="sapientml.export_modules")
for ep in eps:
    for file in glob(f"{ep.load().__path__[0]}/*.py"):
        copyfile(file, lib_path / Path(file).name)
```
Modifications:
・The output code is created by the generator, and the required libraries depend on it.
・For each additional feature, rename the "sapientml.export_modules" plug-in from sample-dataset to the name of each generator.
・sapientml identifies the required library from the generator name and outputs it.
・However, the sapientml"sample-dataset" library is required for all output code and is output every time.

Impact:
・You also need to modify core. See: [#49](https://github.com/sapientml/core/pull/49)