### PR TITLE
Fix: solve a SapientML.predict error when multiclass

### DIFF
--- a/sapientml/main.py
+++ b/sapientml/main.py
@@ -135,21 +135,6 @@ class SapientML:
             Valid only when task_type='classification'.
 
         """
-        self.params = {
-            "target_columns": target_columns,
-            "task_type": task_type,
-            "split_method": split_method,
-            "split_seed": split_seed,
-            "split_train_size": split_train_size,
-            "split_column_name": split_column_name,
-            "time_split_num": time_split_num,
-            "time_split_index": time_split_index,
-            "adaptation_metric": adaptation_metric,
-            "split_stratification": split_stratification,
-            "model_type": model_type,
-            **kwargs,
-        }
-
         self.task = Task(
             target_columns=target_columns,
             task_type=task_type,
@@ -338,6 +323,12 @@ class SapientML:
         self.generator.generate_pipeline(self.dataset, self.task)
         self.dataset.reload()
         self.generator.save(self.output_dir)
+
+        self.params = {
+            "model_type": self.model_type,
+            "task": self.task.model_dump(),
+            "config": self.config.model_dump()
+        }
 
         self.model = GeneratedModel(
             input_dir=self.output_dir,

--- a/sapientml/main.py
+++ b/sapientml/main.py
@@ -324,11 +324,11 @@ class SapientML:
         self.dataset.reload()
         self.generator.save(self.output_dir)
 
-        self.params = {
-            "model_type": self.model_type,
-            "task": self.task.model_dump(),
-            "config": self.config.model_dump()
-        }
+        self.params = {"model_type": self.model_type}
+        self.params.update(self.task.model_dump())
+        self.params.update(self.config.model_dump())
+        self.params.update(self.generator.loaddata.config.model_dump())
+        self.params.update(self.generator.preprocess.config.model_dump())
 
         self.model = GeneratedModel(
             input_dir=self.output_dir,

--- a/sapientml/model.py
+++ b/sapientml/model.py
@@ -157,6 +157,8 @@ class GeneratedModel:
             result = run(str(temp_dir / "final_predict.py"), self.timeout)
             if result.returncode != 0:
                 raise RuntimeError(f"Prediction was failed due to the following Error: {result.error}")
-            result_df = pd.read_csv(temp_dir / "prediction_result.csv")
-            result_df = result_df[self.params["target_columns"]]
+            id_columns_for_prediction = self.params['config'].get('id_columns_for_prediction', [])
+            if not id_columns_for_prediction:
+                id_columns_for_prediction = [0]
+            result_df = pd.read_csv(temp_dir / "prediction_result.csv", index_col=id_columns_for_prediction)
             return result_df

--- a/sapientml/model.py
+++ b/sapientml/model.py
@@ -157,7 +157,7 @@ class GeneratedModel:
             result = run(str(temp_dir / "final_predict.py"), self.timeout)
             if result.returncode != 0:
                 raise RuntimeError(f"Prediction was failed due to the following Error: {result.error}")
-            id_columns_for_prediction = self.params['config'].get('id_columns_for_prediction', [])
+            id_columns_for_prediction = self.params.get("id_columns_for_prediction", [])
             if not id_columns_for_prediction:
                 id_columns_for_prediction = [0]
             result_df = pd.read_csv(temp_dir / "prediction_result.csv", index_col=id_columns_for_prediction)

--- a/tests/sapientml/test_sapientml.py
+++ b/tests/sapientml/test_sapientml.py
@@ -139,6 +139,7 @@ def test_sapientml_works_with_pickled_model(testdata_df_light):
         testdata_df_light,
     )
 
+
 def test_sapientml_works_with_probability_prediction_for_multiclass_with_id(testdata_df_light):
     cls_ = SapientML(
         ["target_category_multi_nonnum"],

--- a/tests/sapientml/test_sapientml.py
+++ b/tests/sapientml/test_sapientml.py
@@ -139,6 +139,22 @@ def test_sapientml_works_with_pickled_model(testdata_df_light):
         testdata_df_light,
     )
 
+def test_sapientml_works_with_probability_prediction_for_multiclass_with_id(testdata_df_light):
+    cls_ = SapientML(
+        ["target_category_multi_nonnum"],
+        task_type="classification",
+        id_columns_for_prediction=["id"],
+        initial_timeout=60,
+    )
+    test_df = testdata_df_light.copy()
+    test_df['id'] = np.arange(test_df.shape[0])
+    cls_.fit(
+        test_df,
+    )
+    cls_.predict(
+        test_df,
+    )
+
 
 def test_misc_sapientml_with_hpo_works(testdata_df_light, caplog):
     testdata_df_light = testdata_df_light[["target_number", "explanatory_multi_category_nonnum"]]

--- a/tests/sapientml/test_sapientml.py
+++ b/tests/sapientml/test_sapientml.py
@@ -147,7 +147,7 @@ def test_sapientml_works_with_probability_prediction_for_multiclass_with_id(test
         initial_timeout=60,
     )
     test_df = testdata_df_light.copy()
-    test_df['id'] = np.arange(test_df.shape[0])
+    test_df["id"] = np.arange(test_df.shape[0])
     cls_.fit(
         test_df,
     )


### PR DESCRIPTION
The PR solves an issue that `SapientML.predict()` fails when the metric requires `predict_proba()` such as AUC and the task is multiclass classification. The failure occurs because the prediction column names are not the target columns, but the classes.

The example code is: 
```python
import pandas as pd
from sapientml import SapientML
from sklearn import datasets

iris = datasets.load_iris()
df = pd.DataFrame(iris.data, columns=iris.feature_names)
df['target'] = iris.target
df['target'] = df['target'].apply(lambda x: iris.target_names[x])

sml = SapientML(
    target_columns=["target"],
    adaptation_metric='AUC',
)

sml.fit(df)
y_pred = sml.predict(df)
print(y_pred)
```

The output is:
```
     setosa  versicolor  virginica
0       1.0         0.0        0.0
1       1.0         0.0        0.0
2       1.0         0.0        0.0
3       1.0         0.0        0.0
4       1.0         0.0        0.0
..      ...         ...        ...
145     0.0         0.0        1.0
146     0.0         0.0        1.0
147     0.0         0.0        1.0
148     0.0         0.0        1.0
149     0.0         0.0        1.0
```

This PR sets "id_columns_for_prediction" as the index. The remaining columns are targets. This PR assumes the first column is the index when "id_columns_for_prediction" is not specified by users.