### PR TITLE
Supporting latest SapientML with python 3.9 version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ homepage = "https://sapientml.io/"
 documentation = "https://sapientml.readthedocs.io/"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.9,<3.13"
 sapientml-core = "*"
 numpy = "^1.19.5"
 pandas = "^2.0.3"

--- a/sapientml/main.py
+++ b/sapientml/main.py
@@ -14,9 +14,9 @@
 
 import glob
 import pickle
+import sys
 
 # from msilib.schema import Error
-from importlib.metadata import entry_points
 from pathlib import Path
 from shutil import copyfile
 from typing import Literal, Optional, Union
@@ -28,6 +28,11 @@ from sapientml.suggestion import SapientMLSuggestion
 from .macros import Metric
 from .params import Dataset, Task
 from .util.logging import setup_logger
+
+if sys.version_info.minor <= 9:
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 logger = setup_logger()
 


### PR DESCRIPTION
Below are the changes that we have added.

1. Modified python version from 3.10 to 3.9 in pyproject.toml file.

    `python = ">=3.9,<3.13"`
 
2. We have also added the following code snippet at sapientml/sapientml/main.py:
    ```
    import sys
    if sys.version_info.minor <= 9:
      from importlib_metadata import entry_points
    else:
      from importlib.metadata import entry_points
    ```